### PR TITLE
feat(locales): add Ukrainian (`uk`) language

### DIFF
--- a/bot/locales/en.toml
+++ b/bot/locales/en.toml
@@ -148,7 +148,7 @@ stats = "Statistics"
 lang = "Switch language"
 
 [lang]
-unknown = "Unknown language: <code>%{lang}</code>. Available: <code>en</code>, <code>ru</code>."
+unknown = "Unknown language: <code>%{lang}</code>. Available: <code>en</code>, <code>ru</code>, <code>uk</code>."
 changed = "Language changed to <b>%{lang}</b>."
 error = "Failed to change language"
 name = "English"

--- a/bot/locales/ru.toml
+++ b/bot/locales/ru.toml
@@ -148,7 +148,7 @@ stats = "Статистика"
 lang = "Сменить язык"
 
 [lang]
-unknown = "Неизвестный язык: <code>%{lang}</code>. Доступные: <code>en</code>, <code>ru</code>."
+unknown = "Неизвестный язык: <code>%{lang}</code>. Доступные: <code>en</code>, <code>ru</code>, <code>uk</code>."
 changed = "Язык изменён на <b>%{lang}</b>."
 error = "Не удалось сменить язык"
 name = "Русский"

--- a/bot/locales/uk.toml
+++ b/bot/locales/uk.toml
@@ -1,0 +1,154 @@
+_version = 1
+
+[start]
+source_code_label = "вихідний код"
+body = """
+<b>Команди</b>
+- <code>/vd</code> — завантажити відео. Використовуйте цю команду, щоб бачити прогрес \
+завантаження; без неї завантаження відбувається в «тихому» режимі.
+- <code>/ad</code> — завантажити аудіо
+- <code>/pd</code> — завантажити фото
+- <code>/rv</code>, <code>/ra</code> — випадкове відео або аудіо
+- <code>/shazam</code> — розпізнати пісню з голосового, аудіо чи відео у відповіді
+- <code>/add_ed</code> — виключити домен із завантаження
+- <code>/rm_ed</code> — повернути домен до завантаження
+- <code>/change_link_visibility</code> — показувати або приховувати посилання в підписі до медіа
+- <code>/stats</code> — статистика використання
+- <code>/lang</code> — змінити мову інтерфейсу
+
+<b>Inline-режим</b>
+- <code>@%{username} &lt;посилання&gt;</code> — завантажити за посиланням
+- <code>@%{username} &lt;назва&gt;</code> — пошук на YouTube
+
+<b>Аргументи</b>
+Для <code>/vd</code> і <code>/ad</code>:
+  - lang: бажана мова аудіо, приклад: <code>/vd [lang=uk]</code>
+  - items: завантаження плейлиста, <code>початок:кінець:крок</code> \
+(за замовчуванням: 1 для кожного параметра, не більше 10 файлів за команду), \
+приклад: <code>/vd [items=1:3:1]</code>
+  - overwrite: примусово завантажити заново та замінити кеш, \
+приклад: <code>/vd [overwrite=true]</code>
+  - crop: завантажити лише вказаний фрагмент, формат <code>початок-кінець</code>, \
+підтримується <code>гг:хх:сс</code> (за замовчуванням: 0 для початку, порожньо для кінця), \
+приклад: <code>/vd [crop=00:01:30-]</code>
+Для <code>/rv</code> і <code>/ra</code>:
+  - domains: джерела через <code>|</code>, приклад: <code>/rv [domains=youtube.com|youtu.be]</code>
+
+<b>Примітки</b>
+- Аргументи вказуються у квадратних дужках через кому: <code>[arg=value,arg2=value]</code>;
+- Усі аргументи необов’язкові;
+- Підтримуються тисячі сайтів;
+- Inline-режим підтримує <code>lang</code> і <code>overwrite</code>, але не підтримує <code>items</code>;
+- Щоб бот проігнорував посилання, додайте до нього <code>yv2t_bot=false</code>;
+- Завантажую медіа в найкращій якості, до %{max_file_size_in_mb} МБ;
+- Бот із відкритим вихідним кодом: %{source_code}.\
+"""
+
+[link_visibility]
+changed_to_visible = "Посилання в підписі тепер <b>відображається</b>"
+changed_to_hidden = "Посилання в підписі тепер <b>приховане</b>"
+error = "Не вдалося змінити видимість посилання"
+private_only = "Використовуйте цю команду в приватному чаті"
+
+[exclude_domain]
+already_in_list = "Цей домен уже є в списку виключень"
+limit_reached = "Список виключень переповнений. Максимум — 15 доменів."
+not_in_list = "Домен не знайдено в списку виключень"
+add_error = "Не вдалося додати домен"
+remove_error = "Не вдалося видалити домен"
+current_list_header = "Поточний список виключень:"
+added_template = """
+Домен %{domain} додано до списку виключень.
+Посилання з цього хоста не завантажуватимуться в «тихому» режимі.
+Видалити його зі списку можна командою <code>/rm_exclude_domain</code>.\
+"""
+removed_template = """
+Домен %{domain} видалено зі списку виключень.
+Повернути його назад можна командою <code>/add_exclude_domain</code>.\
+"""
+
+[stats]
+body = """
+<b>Статистика</b>
+- Кількість чатів: %{chats_count}
+- За типами:
+%{chat_types}\
+- Завантажено за 1/7/30 днів / загалом: %{d1}/%{d7}/%{d30}/%{total}
+- Ноди:
+%{nodes}- Черга (воркерів: %{workers}):
+  - В очікуванні: %{queue_waiting}
+  - В обробці: %{queue_in_progress}
+  - З помилкою: %{queue_dead_letter}
+- Найпопулярніші домени:
+%{top_domains}\
+"""
+chat_type_line = "  - %{chat_type}: %{count}"
+chat_type_private = "Приватні"
+chat_type_group = "Групи"
+chat_type_supergroup = "Супергрупи"
+chat_type_channel = "Канали"
+chat_type_unknown = "Невідомо"
+node_line = "%{name}. (%{active}/%{max})"
+top_domain_line = "%{index}. %{domain} (%{count} шт.)"
+get_error = "Не вдалося отримати статистику"
+
+[progress]
+sending = "Надсилаю..."
+downloading = "Завантажую..."
+downloading_playlist = "Завантажую плейлист... %{current}/%{total}"
+media_progress = "Прогрес завантаження: %{progress}"
+error_downloading = "Помилка під час завантаження :("
+error_downloading_some = "Не вдалося завантажити деякі файли :("
+download_retries = "Спроб завантаження: %{count}"
+media_download_retries = "%{n} файл(ів) (спроб завантаження: %{count}):"
+
+[download]
+error_queue = "Не вдалося поставити завантаження в чергу. Спробуйте пізніше."
+preparing = "Підготовка до завантаження..."
+playlist_empty = "Плейлист порожній"
+no_media_found = "Медіа не знайдено"
+error_parse_range = "Не вдалося розібрати діапазон"
+error_parse_sections = "Не вдалося розібрати обрізку"
+error_get_info = "Не вдалося отримати інформацію"
+error_get_media = "Не вдалося отримати медіа"
+error_send_media = "Не вдалося надіслати медіа"
+error_send_playlist = "Не вдалося надіслати плейлист"
+error_download_playlist = "Не вдалося завантажити плейлист"
+error_edit_message = "Не вдалося змінити повідомлення"
+
+[shazam]
+no_audio = "Дайте відповідь на голосове, аудіо чи відео командою /shazam або надішліть такий файл із підписом /shazam."
+too_large = "Це аудіо завелике для розпізнавання. Спробуйте короткий голосовий фрагмент."
+recognizing = "Розпізнаю..."
+no_match = "Не вдалося розпізнати. Спробуйте чіткіший або довший фрагмент."
+error = "Не вдалося розпізнати аудіо :("
+result = "<b>%{title}</b> — %{artist}"
+album = "%{album}"
+link = "<a href=\"%{url}\">Shazam</a>"
+
+[inline]
+no_name = "Без назви"
+download_auto = "Натисніть, щоб завантажити (авто)"
+download_video = "Натисніть, щоб завантажити відео"
+download_audio = "Натисніть, щоб завантажити аудіо"
+download_photo = "Натисніть, щоб завантажити фото"
+error_search_media = "Не вдалося знайти медіа"
+
+[bot_commands]
+start = "Показати довідку"
+vd = "Завантажити відео"
+ad = "Завантажити аудіо"
+rv = "Випадкове відео"
+ra = "Випадкове аудіо"
+add_ed = "Виключити домен"
+rm_ed = "Повернути домен"
+change_link_visibility = "Показувати/приховувати посилання"
+shazam = "Розпізнати пісню"
+stats = "Статистика"
+lang = "Змінити мову"
+
+[lang]
+unknown = "Невідома мова: <code>%{lang}</code>. Доступні: <code>en</code>, <code>ru</code>, <code>uk</code>."
+changed = "Мову змінено на <b>%{lang}</b>."
+error = "Не вдалося змінити мову"
+name = "Українська"

--- a/bot/src/locale.rs
+++ b/bot/src/locale.rs
@@ -3,6 +3,7 @@ pub enum Locale {
     #[default]
     En,
     Ru,
+    Uk,
 }
 
 impl Locale {
@@ -10,6 +11,7 @@ impl Locale {
         match self {
             Self::En => "en",
             Self::Ru => "ru",
+            Self::Uk => "uk",
         }
     }
 
@@ -17,6 +19,7 @@ impl Locale {
         match raw.trim().to_ascii_lowercase().as_str() {
             "en" => Some(Self::En),
             "ru" => Some(Self::Ru),
+            "uk" => Some(Self::Uk),
             _ => None,
         }
     }
@@ -24,6 +27,7 @@ impl Locale {
     pub fn from_code(code: Option<&str>) -> Self {
         match code {
             Some(val) if val.to_ascii_lowercase().starts_with("ru") => Self::Ru,
+            Some(val) if val.to_ascii_lowercase().starts_with("uk") => Self::Uk,
             _ => Self::En,
         }
     }
@@ -31,7 +35,8 @@ impl Locale {
     pub fn toggle(self) -> Self {
         match self {
             Self::En => Self::Ru,
-            Self::Ru => Self::En,
+            Self::Ru => Self::Uk,
+            Self::Uk => Self::En,
         }
     }
 }

--- a/bot/src/utils/startup.rs
+++ b/bot/src/utils/startup.rs
@@ -41,6 +41,12 @@ async fn set_my_commands(bot: Bot) -> HandlerResult {
             .language_code(Locale::Ru.as_str()),
     )
     .await?;
+    bot.send(
+        SetMyCommands::new(build_commands(Locale::Uk.as_str()))
+            .scope(BotCommandScopeAllPrivateChats {})
+            .language_code(Locale::Uk.as_str()),
+    )
+    .await?;
     Ok(())
 }
 


### PR DESCRIPTION
Add the Ukrainian (`uk`) locale:

- `bot/locales/uk.toml` — full translation of all sections
- `Locale::Uk` variant: `as_str`, `parse`, `from_code` (auto-detect for Telegram `language_code` starting with `uk`), `toggle` now cycles `en` → `ru` → `uk`
- bot commands registered via `SetMyCommands` with `language_code = "uk"`
- `lang.unknown` in `en`/`ru` updated to list `uk`